### PR TITLE
Arbitrary code execution fix: Replace exec with execFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
-const exec = require('child_process').exec;
+const exec = require('child_process').execFile;
 
 // function timeDifference(startTimeInMilliSeconds, endTimeInMilliSeconds) {
 //   return formattedTime(timeInMilliSeconds(endTimeInMilliSeconds) - timeInMilliSeconds(startTimeInMilliSeconds));
 // }
 
-function execute(command) {
+const COMMAND = 'ffmpeg';
+
+function execute(args) {
   return new Promise((resolve, reject) => {
-    exec(command, (error, stdout, stderr) => {
+    exec(COMMAND, args, (error, stdout, stderr) => {
       if (error) {
         reject(stderr);
       } else {
@@ -33,7 +35,7 @@ function formattedTime(milliSeconds) {
 
 function clip(inputFilePath, outputFilePath, startTime, endTime) {
   let duration = endTime - startTime;
-  return execute(`ffmpeg -ss ${formattedTime(startTime)} -i ${inputFilePath} -t ${formattedTime(duration)} ${outputFilePath} -y`);
+  return execute(['-ss', formattedTime(startTime), '-i', inputFilePath, '-t', formattedTime(duration), outputFilePath, '-y']);
 }
 
 function split(inputFilePath, outputFilePath, clipPoints) {
@@ -47,11 +49,11 @@ splitQueue.push(clip(inputFilePath, `${ci}-${outputFilePath}`, clipPoints[ci], c
 }
 
 function parseAudio(inputFilePath, outputFilePath) {
-  return execute(`ffmpeg -i ${inputFilePath} -f mp2 ${outputFilePath}`);
+  return execute(['-i', inputFilePath, '-f', 'mp2', outputFilePath]);
 }
 
 function parseAudioLowQuality(inputFilePath, outputFilePath) {
-  return execute(`ffmpeg -i ${inputFilePath} -ac 1 -ab 64000 ${outputFilePath}`);
+  return execute(['-i', inputFilePath, '-ac', '1', '-ab', '64000', outputFilePath]);
 }
 
 module.exports = {


### PR DESCRIPTION
### 📊 Metadata *

`ffmpeg-sdk` is vulnerable to `Command Injection`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-ffmpeg-sdk/

### ⚙️ Description *

Used child_process.execFile() instead of child_process.exec().

### 💻 Technical Description *

The use of the child_process function exec() is highly discouraged if you accept user input and don't sanitize/escape them. This PR replaces it with execFile() which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:
```

// poc.js
var root = require("ffmpeg-sdk");
root.execute("touch HACKED");
```

2. Execute the following commands in terminal:

```
npm i ffmpeg-sdk # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output using ls command before and after the execution.

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106952322-f75f5300-6756-11eb-98f2-36a075070bbf.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106952401-14942180-6757-11eb-8035-7bf920f052c9.png)

### 👍 User Acceptance Testing (UAT)

Breaking changes introduced. `execute` function now only accepts arguments of type `Array`. Arbitrary execution is mitigated by restricting `execute` function to run only package related commands.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1842
